### PR TITLE
add systray option to toggle auto-profile-switching

### DIFF
--- a/Source/AutoActions.ProjectResources/ProjectLocales.Designer.cs
+++ b/Source/AutoActions.ProjectResources/ProjectLocales.Designer.cs
@@ -250,6 +250,15 @@ namespace AutoActions.ProjectResources {
         }
         
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Automatic profile switching ähnelt.
+        /// </summary>
+        public static string AutoProfileSwitching {
+            get {
+                return ResourceManager.GetString("AutoProfileSwitching", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Auto-Start ähnelt.
         /// </summary>
         public static string AutoStart {

--- a/Source/AutoActions.ProjectResources/ProjectLocales.de.resx
+++ b/Source/AutoActions.ProjectResources/ProjectLocales.de.resx
@@ -174,6 +174,9 @@
   <data name="AutoActionsToolTip" xml:space="preserve">
     <value>Aktivere HDR für diesen Monitor, basierend auf der Anwendung.</value>
   </data>
+  <data name="AutoProfileSwitching" xml:space="preserve">
+    <value>Automatischer Profilwechsel</value>
+  </data>
   <data name="AutoStart" xml:space="preserve">
     <value>Auto-Start</value>
   </data>

--- a/Source/AutoActions.ProjectResources/ProjectLocales.resx
+++ b/Source/AutoActions.ProjectResources/ProjectLocales.resx
@@ -180,6 +180,9 @@
   <data name="AutoActionsToolTip" xml:space="preserve">
     <value>Enable HDR on this monitor, based on the applications</value>
   </data>
+  <data name="AutoProfileSwitching" xml:space="preserve">
+    <value>Automatic profile switching</value>
+  </data>
   <data name="AutoStart" xml:space="preserve">
     <value>Auto-Start</value>
   </data>

--- a/Source/AutoActions/AutoActionsDaemon.cs
+++ b/Source/AutoActions/AutoActionsDaemon.cs
@@ -203,6 +203,11 @@ namespace AutoActions
             try
             {
                 Globals.Logs.Add($"Application {e.Application} changed: {e.ChangedType}", false);
+                if (!Settings.AutoProfileSwitchingEnabled)
+                {
+                    Globals.Logs.Add($"Automatic profile switching is disabled. Ignoring application change.", false);
+                    return;
+                }
                 CurrentApplication = e.Application;
                 UpdateCurrentProfile(e.Application, e.ChangedType);
                 if (e.ChangedType == ApplicationChangedType.Closed)

--- a/Source/AutoActions/TrayMenuHelper.cs
+++ b/Source/AutoActions/TrayMenuHelper.cs
@@ -25,6 +25,7 @@ namespace AutoActions
         private MenuItem _closeButton;
         private MenuItem _appplications;
         private MenuItem _actions;
+        private MenuItem _autoProfileSwitching;
 
 
         public event EventHandler OpenViewRequested;
@@ -60,6 +61,7 @@ namespace AutoActions
                 contextMenu.Items.Add(_openButton);
                 InitializeApplicationsMenuItem(contextMenu);
                 InitializeActionsMenuItem(contextMenu);
+                InitializeAutoProfileSwitchingMenuItem(contextMenu);
                 contextMenu.Items.Add(_closeButton);
                 _trayMenu.ContextMenu = contextMenu;
                 _trayMenu.TrayLeftMouseDown += TrayMenu_TrayLeftMouseDown;
@@ -76,6 +78,23 @@ namespace AutoActions
         }
 
         readonly object _lockActions = new object();
+
+        private void InitializeAutoProfileSwitchingMenuItem(ContextMenu contextMenu)
+        {
+            _autoProfileSwitching = new MenuItem()
+            {
+                Header = ProjectLocales.AutoProfileSwitching,
+                IsCheckable = true,
+                IsChecked = Globals.Instance.Settings.AutoProfileSwitchingEnabled
+            };
+            _autoProfileSwitching.Click += (o, e) => Globals.Instance.Settings.AutoProfileSwitchingEnabled = _autoProfileSwitching.IsChecked;
+            Globals.Instance.Settings.PropertyChanged += (o, e) =>
+            {
+                if (e.PropertyName == nameof(UserAppSettings.AutoProfileSwitchingEnabled))
+                    _autoProfileSwitching.Dispatcher.Invoke(() => _autoProfileSwitching.IsChecked = Globals.Instance.Settings.AutoProfileSwitchingEnabled);
+            };
+            contextMenu.Items.Add(_autoProfileSwitching);
+        }
 
         private void InitializeActionsMenuItem(ContextMenu contextMenu)
         {

--- a/Source/AutoActions/UserAppSettings.cs
+++ b/Source/AutoActions/UserAppSettings.cs
@@ -19,6 +19,7 @@ namespace AutoActions
         public static readonly object _settingsLock = new object();
 
         private bool _globalAutoActions = true;
+        private bool _autoProfileSwitchingEnabled = true;
         private bool _createLogFile = false;
         private bool _autoStart = false;
         private bool _autoUpdate = true;
@@ -47,6 +48,9 @@ namespace AutoActions
 
         [JsonProperty]
         public bool GlobalAutoActions { get => _globalAutoActions; set { _globalAutoActions = value; OnPropertyChanged(); } }
+
+        [JsonProperty]
+        public bool AutoProfileSwitchingEnabled { get => _autoProfileSwitchingEnabled; set { _autoProfileSwitchingEnabled = value; OnPropertyChanged(); } }
 
         [JsonProperty]
         public bool AutoStart { get => _autoStart; set { _autoStart = value; OnPropertyChanged(); } }


### PR DESCRIPTION
this PR adds an option to the systray context menu that will guard whether or not profile auto switching occurs. useful for quickly turning it off when you don't want the profile to change.